### PR TITLE
fix/Check for ref.current before applying styles

### DIFF
--- a/src/components/pull-to-refresh.tsx
+++ b/src/components/pull-to-refresh.tsx
@@ -211,13 +211,15 @@ const PullToRefresh: React.FC<PullToRefreshProps> = ({
 
     // Container has not been dragged enough, put it back to it's initial state
     if (!pullToRefreshThresholdBreached) {
-      pullDownRef.current!.style.visibility = 'hidden';
+      if (pullDownRef.current) pullDownRef.current!.style.visibility = 'hidden';
       initContainer();
       return;
     }
 
-    childrenRef.current!.style.overflow = 'visible';
-    childrenRef.current!.style.transform = `translate(0px, ${pullDownThreshold}px)`;
+    if (childrenRef.current) {
+      childrenRef.current!.style.overflow = 'visible';
+      childrenRef.current!.style.transform = `translate(0px, ${pullDownThreshold}px)`;
+    }
     onRefresh().then(initContainer).catch(initContainer);
   };
 

--- a/src/components/pull-to-refresh.tsx
+++ b/src/components/pull-to-refresh.tsx
@@ -161,7 +161,7 @@ const PullToRefresh: React.FC<PullToRefreshProps> = ({
     if (window.TouchEvent && e instanceof TouchEvent) {
       currentY = e.touches[0].pageY;
     } else {
-      currentY = e.pageY;
+      currentY = (e as MouseEvent).pageY;
     }
 
     containerRef.current!.classList.add('ptr--dragging');
@@ -211,14 +211,14 @@ const PullToRefresh: React.FC<PullToRefreshProps> = ({
 
     // Container has not been dragged enough, put it back to it's initial state
     if (!pullToRefreshThresholdBreached) {
-      if (pullDownRef.current) pullDownRef.current!.style.visibility = 'hidden';
+      if (pullDownRef.current) pullDownRef.current.style.visibility = 'hidden';
       initContainer();
       return;
     }
 
     if (childrenRef.current) {
-      childrenRef.current!.style.overflow = 'visible';
-      childrenRef.current!.style.transform = `translate(0px, ${pullDownThreshold}px)`;
+      childrenRef.current.style.overflow = 'visible';
+      childrenRef.current.style.transform = `translate(0px, ${pullDownThreshold}px)`;
     }
     onRefresh().then(initContainer).catch(initContainer);
   };

--- a/src/components/pull-to-refresh.tsx
+++ b/src/components/pull-to-refresh.tsx
@@ -138,7 +138,7 @@ const PullToRefresh: React.FC<PullToRefreshProps> = ({
     if (e instanceof MouseEvent) {
       startY = e.pageY;
     }
-    if (e instanceof TouchEvent) {
+    if (window.TouchEvent && e instanceof TouchEvent) {
       startY = e.touches[0].pageY;
     }
     currentY = startY;
@@ -158,7 +158,7 @@ const PullToRefresh: React.FC<PullToRefreshProps> = ({
       return;
     }
 
-    if (e instanceof TouchEvent) {
+    if (window.TouchEvent && e instanceof TouchEvent) {
       currentY = e.touches[0].pageY;
     } else {
       currentY = e.pageY;


### PR DESCRIPTION
Hello,
I came across this bug when navigating through pages. 

When I pull to fetch data and then immidietly navigate to new page (using Next), the code wants to edit styles on previues page and throws Null error on refs.

Feel free to fix it with null null coalescing, I just made a quick PR to point out the problem.

Thanks a lot, Jakub.
 
 