### PR TITLE
Use optional chaining instead of non-null assert

### DIFF
--- a/src/components/pull-to-refresh.tsx
+++ b/src/components/pull-to-refresh.tsx
@@ -176,22 +176,22 @@ const PullToRefresh: React.FC<PullToRefreshProps> = ({
     if (e.cancelable) {
       e.preventDefault();
     }
-      
+
     const yDistanceMoved = Math.min((currentY - startY) / resistance, maxPullDownDistance);
 
     // Limit to trigger refresh has been breached
     if (yDistanceMoved >= pullDownThreshold) {
       isDragging = true;
       pullToRefreshThresholdBreached = true;
-      containerRef.current!.classList.remove('ptr--dragging');
-      containerRef.current!.classList.add('ptr--pull-down-treshold-breached');
+      containerRef.current?.classList.remove('ptr--dragging');
+      containerRef.current?.classList.add('ptr--pull-down-treshold-breached');
     }
 
     // maxPullDownDistance breached, stop the animation
     if (yDistanceMoved >= maxPullDownDistance) {
       return;
     }
-    pullDownRef.current!.style.opacity = ((yDistanceMoved) / 65).toString();
+    pullDownRef.current!.style.opacity = (yDistanceMoved / 65).toString();
     childrenRef.current!.style.overflow = 'visible';
     childrenRef.current!.style.transform = `translate(0px, ${yDistanceMoved}px)`;
     pullDownRef.current!.style.visibility = 'visible';
@@ -207,7 +207,7 @@ const PullToRefresh: React.FC<PullToRefreshProps> = ({
      */
     if (canFetchMore && getScrollToBottomValue() < fetchMoreThreshold && onFetchMore) {
       fetchMoreTresholdBreached = true;
-      containerRef.current!.classList.add('ptr--fetch-more-treshold-breached');
+      containerRef.current?.classList.add('ptr--fetch-more-treshold-breached');
       onFetchMore().then(initContainer).catch(initContainer);
     }
   };


### PR DESCRIPTION
Fix #81 

Due to events like `onScroll` that this library listens to are not synchronous, they can be fired right after the component is already unmounted, causing `ref.current` to be `null`. This PR fixes the issue by using optional chaining instead of non-null assertion on `ref.current` usages.